### PR TITLE
fix: hide meta ai button on home feed

### DIFF
--- a/src/Features/General/HideMetaAI.xm
+++ b/src/Features/General/HideMetaAI.xm
@@ -328,3 +328,14 @@
     }
 }
 %end
+
+// Home feed meta ai button
+%hook IGFloatingActionButton.IGFloatingActionButton
+- (void)didMoveToSuperview {
+    %orig;
+    if ([SCIManager getPref:@"hide_meta_ai"]) {
+        [self removeFromSuperview];
+        NSLog(@"[SCInsta] Hiding meta ai: home feed meta ai button"); 
+    }
+}
+%end


### PR DESCRIPTION
Since updating my Instagram app, I have this meta ai button on the home feed. Seems to be getting A/B tested as I only have it on one of my accounts. This code is removing the button on my end.
![home_meta_ai](https://github.com/user-attachments/assets/05567f3b-2978-4433-a279-f3a9b9d2ce6d)
