### PR TITLE
Create draft release for better downloading speed

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -128,7 +128,7 @@ jobs:
               uses: softprops/action-gh-release@v2.0.6
               with:
                 name: SCInsta_sideloaded_v${{ steps.scinsta_version.outputs.version }}
-                files: ${{ github.workspace }}/main/packages/*.ipa
+                files: ${{ github.workspace }}/main/packages/SCInsta_sideloaded_v*.ipa
                 draft: true
 
             - name: Output Release URL

--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -123,3 +123,14 @@ jobs:
                 name: SCInsta_sideloaded_v${{ steps.scinsta_version.outputs.version }}
                 path: ${{ github.workspace }}/main/packages/${{ steps.package_name.outputs.package }}
                 if-no-files-found: error
+
+            - name: Create Release
+              uses: softprops/action-gh-release@v2.0.6
+              with:
+                name: SCInsta_sideloaded_v${{ steps.scinsta_version.outputs.version }}
+                files: ${{ github.workspace }}/main/packages/*.ipa
+                draft: true
+
+            - name: Output Release URL
+              run: |
+                echo "::notice::Release available at: https://github.com/${{ github.repository }}/releases"


### PR DESCRIPTION
The artifact file seems to be throttled, downloading is really slow. Creating a private draft release offers really good downloading speed. 

Observed this coming from YTMusicUltimate. This snippet too is copied from it. 

https://github.com/Anon-Exploiter/ios-YTMusicUltimate/blob/main/.github/workflows/main.yml#L113