### PR TITLE
ci: pin github actions

### DIFF
--- a/.github/workflows/auto-assign-issue.yml
+++ b/.github/workflows/auto-assign-issue.yml
@@ -11,7 +11,7 @@ jobs:
             issues: write
         steps:
             - name: 'Auto-assign issue'
-              uses: pozil/auto-assign-issue@v1
+              uses: pozil/auto-assign-issue@70adb98ca8b3941524e9ecde48e89067c4f96736 #v3.0.0
               with:
                   assignees: socuul
                   allowNoAssignees: true

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -12,7 +12,7 @@ jobs:
             pull-requests: write
         steps:
             - name: 'Auto-assign PR'
-              uses: pozil/auto-assign-issue@v1
+              uses: pozil/auto-assign-issue@70adb98ca8b3941524e9ecde48e89067c4f96736 #v3.0.0
               with:
                   assignees: socuul
                   allowNoAssignees: true

--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -31,7 +31,7 @@ jobs:
 
         steps:
             - name: Checkout Main
-              uses: actions/checkout@v4
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
               with:
                 path: main
                 submodules: recursive
@@ -43,7 +43,7 @@ jobs:
               run: echo "$(brew --prefix make)/libexec/gnubin" >> $GITHUB_PATH 
 
             - name: Setup Theos
-              uses: actions/checkout@v4
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
               with:
                 repository: theos/theos
                 ref: master
@@ -52,7 +52,7 @@ jobs:
         
             - name: SDK Caching
               id: SDK
-              uses: actions/cache@v4
+              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #v5.0.5
               env:
                 cache-name: iPhoneOS16.2.sdk
               with:
@@ -120,14 +120,14 @@ jobs:
 
             - name: Upload Artifact
               if: ${{ inputs.upload_artifact }}
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
               with:
                 name: SCInsta_sideloaded_v${{ steps.scinsta_version.outputs.version }}
                 path: ${{ github.workspace }}/main/packages/${{ steps.package_name.outputs.package }}
                 if-no-files-found: error
 
             - name: Create Release
-              uses: softprops/action-gh-release@v2.0.6
+              uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda #v3.0.0
               with:
                 name: SCInsta_sideloaded_v${{ steps.scinsta_version.outputs.version }}
                 files: ${{ github.workspace }}/main/packages/SCInsta_sideloaded_v*.ipa

--- a/.github/workflows/buildtweak.yml
+++ b/.github/workflows/buildtweak.yml
@@ -19,7 +19,7 @@ jobs:
 
         steps:
             - name: Checkout Main
-              uses: actions/checkout@v4
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
               with:
                 path: main
                 submodules: recursive
@@ -31,7 +31,7 @@ jobs:
               run: echo "$(brew --prefix make)/libexec/gnubin" >> $GITHUB_PATH 
 
             - name: Setup Theos
-              uses: actions/checkout@v4
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
               with:
                 repository: theos/theos
                 ref: master
@@ -40,7 +40,7 @@ jobs:
         
             - name: SDK Caching
               id: SDK
-              uses: actions/cache@v4
+              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #v5.0.5
               env:
                 cache-name: iPhoneOS16.2.sdk
               with:
@@ -89,7 +89,7 @@ jobs:
                 echo "package=$(ls -t main/packages | head -n1)" >> "$GITHUB_OUTPUT"
 
             - name: Upload Artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
               with:
                 name: ${{ steps.package_name.outputs.package }}
                 path: ${{ github.workspace }}/main/packages/${{ steps.package_name.outputs.package }}

--- a/.github/workflows/delete-workflow-runs.yml
+++ b/.github/workflows/delete-workflow-runs.yml
@@ -53,7 +53,7 @@ jobs:
       contents: read
     steps:
       - name: Delete workflow runs
-        uses: Mattraks/delete-workflow-runs@v2
+        uses: Mattraks/delete-workflow-runs@b3018382ca039b53d238908238bd35d1fb14f8ee #v2.1.0
         with:
           token: ${{ github.token }}
           repository: ${{ github.repository }}


### PR DESCRIPTION
This updates all actions to latest to support node 24 (https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) and pins the actions to the commit hash of the release (#255)

references:
* https://github.com/pozil/auto-assign-issue/commit/70adb98ca8b3941524e9ecde48e89067c4f96736
* https://github.com/actions/checkout/commit/de0fac2e4500dabe0009e67214ff5f5447ce83dd
* https://github.com/actions/cache/commit/27d5ce7f107fe9357f9df03efb73ab90386fccae
* https://github.com/actions/upload-artifact/commit/043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
* https://github.com/Mattraks/delete-workflow-runs/commit/b3018382ca039b53d238908238bd35d1fb14f8ee
* https://github.com/softprops/action-gh-release/commit/b4309332981a82ec1c5618f44dd2e27cc8bfbfda 


closes #255