### PR TITLE
fix: call %orig for visual messages when unlimited_replay is disabled

### DIFF
--- a/src/Features/StoriesAndMessages/SeenButtons.x
+++ b/src/Features/StoriesAndMessages/SeenButtons.x
@@ -83,6 +83,8 @@
         if (dmVisualMsgsViewedButtonEnabled) {
             %orig;
         }
+    } else {
+        %orig;
     }
 }
 - (void)visualMessageViewerController:(id)arg1 didEndPlaybackForVisualMessage:(id)arg2 atIndex:(NSInteger)arg3 mediaCurrentTime:(CGFloat)arg4 forNavType:(NSInteger)arg5 {
@@ -91,6 +93,8 @@
         if (dmVisualMsgsViewedButtonEnabled) {
             %orig;
         }
+    } else {
+        %orig;
     }
 }
 %end


### PR DESCRIPTION
This PR adds the missing else blocks to ensure the original visual message playback handlers are called when the unlimited replay feature is disabled.