### PR TITLE
feat: support Instagram 435.0.0

### DIFF
--- a/src/Features/General/BlockTestFlightNag.x
+++ b/src/Features/General/BlockTestFlightNag.x
@@ -1,0 +1,29 @@
+#import "../../Utils.h"
+
+// Instagram TestFlight builds periodically present an "update available" nudge
+// (IGCoreRootTestFlightNagPlugin.TestFlightUpdateNudgeViewController).
+// Swallow every attempt to present it, including when wrapped in a navigation controller.
+
+static BOOL SCIIsTestFlightNudge(UIViewController *vc) {
+    if (!vc) return NO;
+
+    UIViewController *target = vc;
+    if ([vc isKindOfClass:[UINavigationController class]]) {
+        target = [(UINavigationController *)vc viewControllers].firstObject ?: vc;
+    }
+
+    NSString *className = NSStringFromClass([target class]);
+    return [className containsString:@"TestFlightUpdateNudgeViewController"];
+}
+
+%hook UIViewController
+- (void)presentViewController:(UIViewController *)vc animated:(BOOL)animated completion:(void (^)(void))completion {
+    if (SCIIsTestFlightNudge(vc)) {
+        NSLog(@"[SCInsta] Blocked TestFlight update nudge: %@", vc);
+        if (completion) completion();
+        return;
+    }
+
+    %orig;
+}
+%end

--- a/src/Features/General/SCSettingsMenuEntry.x
+++ b/src/Features/General/SCSettingsMenuEntry.x
@@ -56,3 +56,53 @@
     [SCIUtils showSettingsVC:[self window]];
 }
 %end
+
+// Tapping the side tray (hamburger) button on the profile lets the user choose
+// between the normal Instagram settings and the SCInsta tweak settings
+@protocol SCSideTrayController
+- (void)onSideTrayButton;
+@end
+
+static BOOL sciBypassSideTray = NO;
+
+%hook _TtC19IGProfileNavigation34IGProfileNavigationItemsController
+- (void)onSideTrayButton {
+    // Re-entrant call from the "Instagram Settings" option: run the original
+    if (sciBypassSideTray) {
+        sciBypassSideTray = NO;
+        %orig;
+        return;
+    }
+
+    UIWindow *window = [[UIApplication sharedApplication] keyWindow];
+    UIViewController *presenter = [window rootViewController];
+    while (presenter.presentedViewController) presenter = presenter.presentedViewController;
+
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Settings"
+                                                                  message:@"Which settings would you like to open?"
+                                                           preferredStyle:UIAlertControllerStyleActionSheet];
+
+    [alert addAction:[UIAlertAction actionWithTitle:@"Instagram Settings"
+                                              style:UIAlertActionStyleDefault
+                                            handler:^(UIAlertAction *action) {
+        sciBypassSideTray = YES;
+        [(id<SCSideTrayController>)self onSideTrayButton];
+    }]];
+
+    [alert addAction:[UIAlertAction actionWithTitle:@"SCInsta Settings"
+                                              style:UIAlertActionStyleDefault
+                                            handler:^(UIAlertAction *action) {
+        [SCIUtils showSettingsVC:window];
+    }]];
+
+    [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+
+    // Required for iPad to avoid a crash when presenting an action sheet
+    if (alert.popoverPresentationController) {
+        alert.popoverPresentationController.sourceView = presenter.view;
+        alert.popoverPresentationController.sourceRect = CGRectMake(presenter.view.bounds.size.width / 2.0, presenter.view.bounds.size.height / 2.0, 1.0, 1.0);
+    }
+
+    [presenter presentViewController:alert animated:YES completion:nil];
+}
+%end

--- a/src/Features/Media/MediaDownload.xm
+++ b/src/Features/Media/MediaDownload.xm
@@ -172,8 +172,16 @@ static void initDownloaders () {
 }
 %new - (void)handleLongPress:(UILongPressGestureRecognizer *)sender {
     if (sender.state != UIGestureRecognizerStateBegan) return;
-    
-    NSURL *videoUrl = [SCIUtils getVideoUrlForMedia:self.video];
+
+    // Older versions expose the media via `video`; newer ones store it in the
+    // `_mediaPassthrough` ivar, so fall back to KVC when `video` is unavailable.
+    IGMedia *media = [self respondsToSelector:@selector(video)] ? self.video : nil;
+    if (!media) {
+        @try { media = [self valueForKey:@"mediaPassthrough"]; }
+        @catch (NSException *e) { media = nil; }
+    }
+
+    NSURL *videoUrl = [SCIUtils getVideoUrlForMedia:media];
     if (!videoUrl) {
         [SCIUtils showErrorHUDWithDescription:@"Could not extract video url from reel"];
 

--- a/src/InstagramHeaders.h
+++ b/src/InstagramHeaders.h
@@ -151,6 +151,9 @@
 @end
 
 @interface IGSundialViewerVideoCell : UIView
+{
+    IGMedia *_mediaPassthrough;
+}
 @property(readonly, nonatomic) IGMedia *video;
 
 - (void)addLongPressGestureRecognizer; // new


### PR DESCRIPTION
- Add settings chooser on profile side tray button (IG vs SCInsta settings)
- Fall back to _mediaPassthrough ivar for reel video download when video is unavailable