### PR TITLE
fix: compilation errors due to %orig

### DIFF
--- a/src/Features/Confirm/CallConfirm.x
+++ b/src/Features/Confirm/CallConfirm.x
@@ -1,25 +1,47 @@
+#import <substrate.h>
 #import "../../Utils.h"
 
-%hook IGDirectThreadCallButtonsCoordinator
+// NOTE: Logos' bare %orig substitution corrupts the surrounding braces when
+// used inside a nested block literal (e.g. inside a showConfirmation
+// completion handler), so these hooks are implemented manually via
+// MSHookMessageEx with a captured C function pointer instead of %hook/%orig.
+
 // Voice Call
-- (void)_didTapAudioButton:(id)arg1 {
+static void (*orig_didTapAudioButton)(id, SEL, id);
+static void hooked_didTapAudioButton(id self, SEL _cmd, id arg1) {
     if ([SCIUtils getBoolPref:@"call_confirm"]) {
         NSLog(@"[SCInsta] Call confirm triggered");
 
-        [SCIUtils showConfirmation:^(void) { %orig; }];
-    } else {
-        return %orig;
+        [SCIUtils showConfirmation:^(void) {
+            orig_didTapAudioButton(self, _cmd, arg1);
+        }];
+
+        return;
     }
+
+    orig_didTapAudioButton(self, _cmd, arg1);
 }
 
 // Video Call
-- (void)_didTapVideoButton:(id)arg1 {
+static void (*orig_didTapVideoButton)(id, SEL, id);
+static void hooked_didTapVideoButton(id self, SEL _cmd, id arg1) {
     if ([SCIUtils getBoolPref:@"call_confirm"]) {
         NSLog(@"[SCInsta] Call confirm triggered");
-        
-        [SCIUtils showConfirmation:^(void) { %orig; }];
-    } else {
-        return %orig;
+
+        [SCIUtils showConfirmation:^(void) {
+            orig_didTapVideoButton(self, _cmd, arg1);
+        }];
+
+        return;
     }
+
+    orig_didTapVideoButton(self, _cmd, arg1);
 }
-%end
+
+%ctor {
+    Class cls = objc_getClass("IGDirectThreadCallButtonsCoordinator");
+    if (!cls) return;
+
+    MSHookMessageEx(cls, @selector(_didTapAudioButton:), (IMP)hooked_didTapAudioButton, (IMP *)&orig_didTapAudioButton);
+    MSHookMessageEx(cls, @selector(_didTapVideoButton:), (IMP)hooked_didTapVideoButton, (IMP *)&orig_didTapVideoButton);
+}

--- a/src/Features/Confirm/ChangeThemeConfirm.x
+++ b/src/Features/Confirm/ChangeThemeConfirm.x
@@ -1,35 +1,68 @@
+#import <substrate.h>
 #import "../../InstagramHeaders.h"
 #import "../../Utils.h"
 
-%hook IGDirectThreadThemePickerViewController
-- (void)themeNewPickerSectionController:(id)arg1 didSelectTheme:(id)arg2 atIndex:(NSInteger)arg3 {
+// NOTE: Logos' bare %orig substitution corrupts the surrounding braces when
+// used inside a nested block literal (e.g. inside a showConfirmation
+// completion handler), so these hooks are implemented manually via
+// MSHookMessageEx with a captured C function pointer instead of %hook/%orig.
+
+static void (*orig_themeNewPickerSectionControllerDidSelectTheme)(id, SEL, id, id, NSInteger);
+static void hooked_themeNewPickerSectionControllerDidSelectTheme(id self, SEL _cmd, id arg1, id arg2, NSInteger arg3) {
     if ([SCIUtils getBoolPref:@"change_direct_theme_confirm"]) {
         NSLog(@"[SCInsta] Confirm change direct theme triggered");
 
-        [SCIUtils showConfirmation:^(void) { %orig; }];
-    } else {
-        return %orig;
+        [SCIUtils showConfirmation:^(void) {
+            orig_themeNewPickerSectionControllerDidSelectTheme(self, _cmd, arg1, arg2, arg3);
+        }];
+
+        return;
     }
+
+    orig_themeNewPickerSectionControllerDidSelectTheme(self, _cmd, arg1, arg2, arg3);
 }
-- (void)themePickerSectionController:(id)arg1 didSelectThemeId:(id)arg2 {
+
+static void (*orig_themePickerSectionControllerDidSelectThemeId)(id, SEL, id, id);
+static void hooked_themePickerSectionControllerDidSelectThemeId(id self, SEL _cmd, id arg1, id arg2) {
     if ([SCIUtils getBoolPref:@"change_direct_theme_confirm"]) {
         NSLog(@"[SCInsta] Confirm change direct theme triggered");
 
-        [SCIUtils showConfirmation:^(void) { %orig; }];
-    } else {
-        return %orig;
-    }
-}
-%end
+        [SCIUtils showConfirmation:^(void) {
+            orig_themePickerSectionControllerDidSelectThemeId(self, _cmd, arg1, arg2);
+        }];
 
-%hook IGDirectThreadThemeKitSwift.IGDirectThreadThemePreviewController
-- (void)primaryButtonTapped {
+        return;
+    }
+
+    orig_themePickerSectionControllerDidSelectThemeId(self, _cmd, arg1, arg2);
+}
+
+static void (*orig_primaryButtonTapped)(id, SEL);
+static void hooked_primaryButtonTapped(id self, SEL _cmd) {
     if ([SCIUtils getBoolPref:@"change_direct_theme_confirm"]) {
         NSLog(@"[SCInsta] Confirm change direct theme triggered");
 
-        [SCIUtils showConfirmation:^(void) { %orig; }];
-    } else {
-        return %orig;
+        [SCIUtils showConfirmation:^(void) {
+            orig_primaryButtonTapped(self, _cmd);
+        }];
+
+        return;
+    }
+
+    orig_primaryButtonTapped(self, _cmd);
+}
+
+%ctor {
+    Class cls;
+
+    cls = objc_getClass("IGDirectThreadThemePickerViewController");
+    if (cls) {
+        MSHookMessageEx(cls, @selector(themeNewPickerSectionController:didSelectTheme:atIndex:), (IMP)hooked_themeNewPickerSectionControllerDidSelectTheme, (IMP *)&orig_themeNewPickerSectionControllerDidSelectTheme);
+        MSHookMessageEx(cls, @selector(themePickerSectionController:didSelectThemeId:), (IMP)hooked_themePickerSectionControllerDidSelectThemeId, (IMP *)&orig_themePickerSectionControllerDidSelectThemeId);
+    }
+
+    cls = objc_getClass("IGDirectThreadThemeKitSwift.IGDirectThreadThemePreviewController");
+    if (cls) {
+        MSHookMessageEx(cls, @selector(primaryButtonTapped), (IMP)hooked_primaryButtonTapped, (IMP *)&orig_primaryButtonTapped);
     }
 }
-%end

--- a/src/Features/Confirm/DMAudioMsgConfirm.x
+++ b/src/Features/Confirm/DMAudioMsgConfirm.x
@@ -1,17 +1,27 @@
+#import <substrate.h>
 #import "../../Utils.h"
 
+// NOTE: Logos' bare %orig substitution corrupts the surrounding braces when
+// used inside a nested block literal (e.g. inside a showConfirmation
+// completion handler), so hooks that defer to a confirmation dialog are
+// implemented manually via MSHookMessageEx with a captured C function
+// pointer instead of %hook/%orig.
+
 // Legacy hook (for non ai voices interface)
-%hook IGDirectThreadViewController
-- (void)voiceRecordViewController:(id)arg1 didRecordAudioClipWithURL:(id)arg2 waveform:(id)arg3 duration:(CGFloat)arg4 entryPoint:(NSInteger)arg5 {
+static void (*orig_voiceRecordViewControllerDidRecordAudioClip)(id, SEL, id, id, id, CGFloat, NSInteger);
+static void hooked_voiceRecordViewControllerDidRecordAudioClip(id self, SEL _cmd, id arg1, id arg2, id arg3, CGFloat arg4, NSInteger arg5) {
     if ([SCIUtils getBoolPref:@"voice_message_confirm"]) {
         NSLog(@"[SCInsta] DM audio message confirm triggered");
 
-        [SCIUtils showConfirmation:^(void) { %orig; }];
-    } else {
-        return %orig;
+        [SCIUtils showConfirmation:^(void) {
+            orig_voiceRecordViewControllerDidRecordAudioClip(self, _cmd, arg1, arg2, arg3, arg4, arg5);
+        }];
+
+        return;
     }
+
+    orig_voiceRecordViewControllerDidRecordAudioClip(self, _cmd, arg1, arg2, arg3, arg4, arg5);
 }
-%end
 
 // Workaround until I can figure out how to stop long press recording from automatically sending
 %hook IGDirectComposer
@@ -25,14 +35,31 @@
 %end
 
 // Demangled name: IGDirectAIVoiceUIKit.CompactBarContentView
-%hook _TtC20IGDirectAIVoiceUIKitP33_5754F7617E0D924F9A84EFA352BBD29A21CompactBarContentView
-- (void)didTapSend {
+static void (*orig_didTapSend)(id, SEL);
+static void hooked_didTapSend(id self, SEL _cmd) {
     if ([SCIUtils getBoolPref:@"voice_message_confirm"]) {
         NSLog(@"[SCInsta] DM audio message confirm triggered");
 
-        [SCIUtils showConfirmation:^(void) { %orig; }];
-    } else {
-        return %orig;
+        [SCIUtils showConfirmation:^(void) {
+            orig_didTapSend(self, _cmd);
+        }];
+
+        return;
+    }
+
+    orig_didTapSend(self, _cmd);
+}
+
+%ctor {
+    Class cls;
+
+    cls = objc_getClass("IGDirectThreadViewController");
+    if (cls) {
+        MSHookMessageEx(cls, @selector(voiceRecordViewController:didRecordAudioClipWithURL:waveform:duration:entryPoint:), (IMP)hooked_voiceRecordViewControllerDidRecordAudioClip, (IMP *)&orig_voiceRecordViewControllerDidRecordAudioClip);
+    }
+
+    cls = objc_getClass("_TtC20IGDirectAIVoiceUIKitP33_5754F7617E0D924F9A84EFA352BBD29A21CompactBarContentView");
+    if (cls) {
+        MSHookMessageEx(cls, @selector(didTapSend), (IMP)hooked_didTapSend, (IMP *)&orig_didTapSend);
     }
 }
-%end

--- a/src/Features/Confirm/FollowConfirm.x
+++ b/src/Features/Confirm/FollowConfirm.x
@@ -1,82 +1,146 @@
+#import <substrate.h>
 #import "../../Utils.h"
 #import "../../InstagramHeaders.h"
 
 ////////////////////////////////////////////////////////
-
-#define CONFIRMFOLLOW(orig)                            \
-    if ([SCIUtils getBoolPref:@"follow_confirm"]) {             \
-        NSLog(@"[SCInsta] Confirm follow triggered");  \
-                                                       \
-        [SCIUtils showConfirmation:^(void) { orig; }]; \
-    }                                                  \
-    else {                                             \
-        return orig;                                   \
-    }                                                  \
-
+// NOTE: Logos' bare %orig substitution corrupts the surrounding braces when
+// used inside a nested block literal (e.g. inside a showConfirmation
+// completion handler). Every hook here that needs to defer the original
+// call until the user confirms is therefore implemented manually via
+// MSHookMessageEx with a captured C function pointer instead of %hook/%orig.
 ////////////////////////////////////////////////////////
 
 // Follow button on profile page
-%hook IGFollowController
-- (void)_didPressFollowButton {
-    // Get user follow status (check if already following user)
-    NSInteger UserFollowStatus = self.user.followStatus;
+static void (*orig_didPressFollowButton)(id, SEL);
+static void hooked_didPressFollowButton(id self, SEL _cmd) {
+    NSInteger UserFollowStatus = ((IGFollowController *)self).user.followStatus;
 
     // Only show confirm dialog if user is not following
-    if (UserFollowStatus == 2) {
-        CONFIRMFOLLOW(%orig);
+    if (UserFollowStatus == 2 && [SCIUtils getBoolPref:@"follow_confirm"]) {
+        NSLog(@"[SCInsta] Confirm follow triggered");
+
+        [SCIUtils showConfirmation:^(void) {
+            orig_didPressFollowButton(self, _cmd);
+        }];
+
+        return;
     }
-    else {
-        return %orig;
-    }
+
+    orig_didPressFollowButton(self, _cmd);
 }
-%end
 
 // Follow button on discover people page
-%hook IGDiscoverPeopleButtonGroupView
-- (void)_onFollowButtonTapped:(id)arg1 {
-    CONFIRMFOLLOW(%orig);
+static void (*orig_onFollowButtonTapped)(id, SEL, id);
+static void hooked_onFollowButtonTapped(id self, SEL _cmd, id arg1) {
+    if ([SCIUtils getBoolPref:@"follow_confirm"]) {
+        NSLog(@"[SCInsta] Confirm follow triggered");
+
+        [SCIUtils showConfirmation:^(void) {
+            orig_onFollowButtonTapped(self, _cmd, arg1);
+        }];
+
+        return;
+    }
+
+    orig_onFollowButtonTapped(self, _cmd, arg1);
 }
-- (void)_onFollowingButtonTapped:(id)arg1 {
-    CONFIRMFOLLOW(%orig);
+
+static void (*orig_onFollowingButtonTapped)(id, SEL, id);
+static void hooked_onFollowingButtonTapped(id self, SEL _cmd, id arg1) {
+    if ([SCIUtils getBoolPref:@"follow_confirm"]) {
+        NSLog(@"[SCInsta] Confirm follow triggered");
+
+        [SCIUtils showConfirmation:^(void) {
+            orig_onFollowingButtonTapped(self, _cmd, arg1);
+        }];
+
+        return;
+    }
+
+    orig_onFollowingButtonTapped(self, _cmd, arg1);
 }
-%end
 
 // Suggested for you (home feed & profile) follow button
-%hook IGHScrollAYMFCell
-- (void)_didTapAYMFActionButton {
-    CONFIRMFOLLOW(%orig);
+static void (*orig_didTapAYMFActionButton)(id, SEL);
+static void hooked_didTapAYMFActionButton(id self, SEL _cmd) {
+    if ([SCIUtils getBoolPref:@"follow_confirm"]) {
+        NSLog(@"[SCInsta] Confirm follow triggered");
+
+        [SCIUtils showConfirmation:^(void) {
+            orig_didTapAYMFActionButton(self, _cmd);
+        }];
+
+        return;
+    }
+
+    orig_didTapAYMFActionButton(self, _cmd);
 }
-%end
-%hook IGHScrollAYMFActionButton
-- (void)_didTapTextActionButton {
-    CONFIRMFOLLOW(%orig);
+
+static void (*orig_didTapTextActionButton)(id, SEL);
+static void hooked_didTapTextActionButton(id self, SEL _cmd) {
+    if ([SCIUtils getBoolPref:@"follow_confirm"]) {
+        NSLog(@"[SCInsta] Confirm follow triggered");
+
+        [SCIUtils showConfirmation:^(void) {
+            orig_didTapTextActionButton(self, _cmd);
+        }];
+
+        return;
+    }
+
+    orig_didTapTextActionButton(self, _cmd);
 }
-%end
 
 // Follow button on reels
-%hook IGUnifiedVideoFollowButton
-- (void)_hackilyHandleOurOwnButtonTaps:(id)arg1 event:(id)arg2 {
-    CONFIRMFOLLOW(%orig);
-}
-%end
+static void (*orig_hackilyHandleOurOwnButtonTaps)(id, SEL, id, id);
+static void hooked_hackilyHandleOurOwnButtonTaps(id self, SEL _cmd, id arg1, id arg2) {
+    if ([SCIUtils getBoolPref:@"follow_confirm"]) {
+        NSLog(@"[SCInsta] Confirm follow triggered");
 
-// Follow text on profile (when collapsed into top bar) 
-%hook IGProfileViewController
-- (void)navigationItemsControllerDidTapHeaderFollowButton:(id)arg1 {
-    CONFIRMFOLLOW(%orig);
+        [SCIUtils showConfirmation:^(void) {
+            orig_hackilyHandleOurOwnButtonTaps(self, _cmd, arg1, arg2);
+        }];
+
+        return;
+    }
+
+    orig_hackilyHandleOurOwnButtonTaps(self, _cmd, arg1, arg2);
 }
-%end
+
+// Follow text on profile (when collapsed into top bar)
+static void (*orig_navigationItemsControllerDidTapHeaderFollowButton)(id, SEL, id);
+static void hooked_navigationItemsControllerDidTapHeaderFollowButton(id self, SEL _cmd, id arg1) {
+    if ([SCIUtils getBoolPref:@"follow_confirm"]) {
+        NSLog(@"[SCInsta] Confirm follow triggered");
+
+        [SCIUtils showConfirmation:^(void) {
+            orig_navigationItemsControllerDidTapHeaderFollowButton(self, _cmd, arg1);
+        }];
+
+        return;
+    }
+
+    orig_navigationItemsControllerDidTapHeaderFollowButton(self, _cmd, arg1);
+}
 
 // Follow button on suggested friends (in story section)
-%hook IGStorySectionController
-- (void)followButtonTapped:(id)arg1 cell:(id)arg2 {
-    CONFIRMFOLLOW(%orig);
+static void (*orig_followButtonTappedCell)(id, SEL, id, id);
+static void hooked_followButtonTappedCell(id self, SEL _cmd, id arg1, id arg2) {
+    if ([SCIUtils getBoolPref:@"follow_confirm"]) {
+        NSLog(@"[SCInsta] Confirm follow triggered");
+
+        [SCIUtils showConfirmation:^(void) {
+            orig_followButtonTappedCell(self, _cmd, arg1, arg2);
+        }];
+
+        return;
+    }
+
+    orig_followButtonTappedCell(self, _cmd, arg1, arg2);
 }
-%end
 
 // Follow all button in group chats (3+ members) people view
 static void (*orig_listSectionController)(id, SEL, id, id);
-
 static void hooked_listSectionController(id self, SEL _cmd, id arg1, id arg2) {
     if ([SCIUtils getBoolPref:@"follow_confirm"]) {
 
@@ -91,13 +155,91 @@ static void hooked_listSectionController(id self, SEL _cmd, id arg1, id arg2) {
 }
 
 %ctor {
-    Class cls = objc_getClass("IGDirectDetailMembersKit.IGDirectThreadDetailsMembersListViewController");
-    if (!cls) return;
+    Class cls;
 
-    MSHookMessageEx(
-        cls,
-        @selector(listSectionController:didTapHeaderButtonWithViewModel:),
-        (IMP)hooked_listSectionController,
-        (IMP *)&orig_listSectionController
-    );
+    cls = objc_getClass("IGFollowController");
+    if (cls) {
+        MSHookMessageEx(
+            cls,
+            @selector(_didPressFollowButton),
+            (IMP)hooked_didPressFollowButton,
+            (IMP *)&orig_didPressFollowButton
+        );
+    }
+
+    cls = objc_getClass("IGDiscoverPeopleButtonGroupView");
+    if (cls) {
+        MSHookMessageEx(
+            cls,
+            @selector(_onFollowButtonTapped:),
+            (IMP)hooked_onFollowButtonTapped,
+            (IMP *)&orig_onFollowButtonTapped
+        );
+        MSHookMessageEx(
+            cls,
+            @selector(_onFollowingButtonTapped:),
+            (IMP)hooked_onFollowingButtonTapped,
+            (IMP *)&orig_onFollowingButtonTapped
+        );
+    }
+
+    cls = objc_getClass("IGHScrollAYMFCell");
+    if (cls) {
+        MSHookMessageEx(
+            cls,
+            @selector(_didTapAYMFActionButton),
+            (IMP)hooked_didTapAYMFActionButton,
+            (IMP *)&orig_didTapAYMFActionButton
+        );
+    }
+
+    cls = objc_getClass("IGHScrollAYMFActionButton");
+    if (cls) {
+        MSHookMessageEx(
+            cls,
+            @selector(_didTapTextActionButton),
+            (IMP)hooked_didTapTextActionButton,
+            (IMP *)&orig_didTapTextActionButton
+        );
+    }
+
+    cls = objc_getClass("IGUnifiedVideoFollowButton");
+    if (cls) {
+        MSHookMessageEx(
+            cls,
+            @selector(_hackilyHandleOurOwnButtonTaps:event:),
+            (IMP)hooked_hackilyHandleOurOwnButtonTaps,
+            (IMP *)&orig_hackilyHandleOurOwnButtonTaps
+        );
+    }
+
+    cls = objc_getClass("IGProfileViewController");
+    if (cls) {
+        MSHookMessageEx(
+            cls,
+            @selector(navigationItemsControllerDidTapHeaderFollowButton:),
+            (IMP)hooked_navigationItemsControllerDidTapHeaderFollowButton,
+            (IMP *)&orig_navigationItemsControllerDidTapHeaderFollowButton
+        );
+    }
+
+    cls = objc_getClass("IGStorySectionController");
+    if (cls) {
+        MSHookMessageEx(
+            cls,
+            @selector(followButtonTapped:cell:),
+            (IMP)hooked_followButtonTappedCell,
+            (IMP *)&orig_followButtonTappedCell
+        );
+    }
+
+    cls = objc_getClass("IGDirectDetailMembersKit.IGDirectThreadDetailsMembersListViewController");
+    if (cls) {
+        MSHookMessageEx(
+            cls,
+            @selector(listSectionController:didTapHeaderButtonWithViewModel:),
+            (IMP)hooked_listSectionController,
+            (IMP *)&orig_listSectionController
+        );
+    }
 }

--- a/src/Features/Confirm/FollowRequestConfirm.xm
+++ b/src/Features/Confirm/FollowRequestConfirm.xm
@@ -1,22 +1,45 @@
+#import <substrate.h>
 #import "../../Utils.h"
 
-%hook IGPendingRequestView
-- (void)_onApproveButtonTapped {
+// NOTE: Logos' bare %orig substitution corrupts the surrounding braces when
+// used inside a nested block literal (e.g. inside a showConfirmation
+// completion handler), so these hooks are implemented manually via
+// MSHookMessageEx with a captured C function pointer instead of %hook/%orig.
+
+static void (*orig_onApproveButtonTapped)(id, SEL);
+static void hooked_onApproveButtonTapped(id self, SEL _cmd) {
     if ([SCIUtils getBoolPref:@"follow_request_confirm"]) {
         NSLog(@"[SCInsta] Confirm follow request triggered");
 
-        [SCIUtils showConfirmation:^(void) { %orig; }];
-    } else {
-        return %orig;
+        [SCIUtils showConfirmation:^(void) {
+            orig_onApproveButtonTapped(self, _cmd);
+        }];
+
+        return;
     }
+
+    orig_onApproveButtonTapped(self, _cmd);
 }
-- (void)_onIgnoreButtonTapped {
+
+static void (*orig_onIgnoreButtonTapped)(id, SEL);
+static void hooked_onIgnoreButtonTapped(id self, SEL _cmd) {
     if ([SCIUtils getBoolPref:@"follow_request_confirm"]) {
         NSLog(@"[SCInsta] Confirm follow request triggered");
 
-        [SCIUtils showConfirmation:^(void) { %orig; }];
-    } else {
-        return %orig;
+        [SCIUtils showConfirmation:^(void) {
+            orig_onIgnoreButtonTapped(self, _cmd);
+        }];
+
+        return;
     }
+
+    orig_onIgnoreButtonTapped(self, _cmd);
 }
-%end
+
+%ctor {
+    Class cls = objc_getClass("IGPendingRequestView");
+    if (!cls) return;
+
+    MSHookMessageEx(cls, @selector(_onApproveButtonTapped), (IMP)hooked_onApproveButtonTapped, (IMP *)&orig_onApproveButtonTapped);
+    MSHookMessageEx(cls, @selector(_onIgnoreButtonTapped), (IMP)hooked_onIgnoreButtonTapped, (IMP *)&orig_onIgnoreButtonTapped);
+}

--- a/src/Features/Confirm/LikeConfirm.x
+++ b/src/Features/Confirm/LikeConfirm.x
@@ -1,116 +1,307 @@
+#import <substrate.h>
 #import "../../Utils.h"
 
 ///////////////////////////////////////////////////////////
-
-// Confirmation handlers
-
-#define CONFIRMPOSTLIKE(orig)                             \
-    if ([SCIUtils getBoolPref:@"like_confirm"]) {           \
-        NSLog(@"[SCInsta] Confirm post like triggered");  \
-                                                          \
-        [SCIUtils showConfirmation:^(void) { orig; }];    \
-    }                                                     \
-    else {                                                \
-        return orig;                                      \
-    }                                                     \
-
-#define CONFIRMREELSLIKE(orig)                            \
-    if ([SCIUtils getBoolPref:@"like_confirm_reels"]) {     \
-        NSLog(@"[SCInsta] Confirm reels like triggered"); \
-                                                          \
-        [SCIUtils showConfirmation:^(void) { orig; }];    \
-    }                                                     \
-    else {                                                \
-        return orig;                                      \
-    }                                                     \
-
+// NOTE: Logos' bare %orig substitution corrupts the surrounding braces when
+// used inside a nested block literal (e.g. inside a showConfirmation
+// completion handler). Every hook here that needs to defer the original
+// call until the user confirms is therefore implemented manually via
+// MSHookMessageEx with a captured C function pointer instead of %hook/%orig.
 ///////////////////////////////////////////////////////////
 
 // Liking posts
-%hook IGUFIButtonBarView
-- (void)_onLikeButtonPressed:(id)arg1 {
-    CONFIRMPOSTLIKE(%orig);
+static void (*orig_onLikeButtonPressed)(id, SEL, id);
+static void hooked_onLikeButtonPressed(id self, SEL _cmd, id arg1) {
+    if ([SCIUtils getBoolPref:@"like_confirm"]) {
+        NSLog(@"[SCInsta] Confirm post like triggered");
+
+        [SCIUtils showConfirmation:^(void) {
+            orig_onLikeButtonPressed(self, _cmd, arg1);
+        }];
+
+        return;
+    }
+
+    orig_onLikeButtonPressed(self, _cmd, arg1);
 }
-%end
-%hook IGFeedPhotoView
-- (void)_onDoubleTap:(id)arg1 {
-    CONFIRMPOSTLIKE(%orig);
+
+static void (*orig_onDoubleTap)(id, SEL, id);
+static void hooked_onDoubleTap(id self, SEL _cmd, id arg1) {
+    if ([SCIUtils getBoolPref:@"like_confirm"]) {
+        NSLog(@"[SCInsta] Confirm post like triggered");
+
+        [SCIUtils showConfirmation:^(void) {
+            orig_onDoubleTap(self, _cmd, arg1);
+        }];
+
+        return;
+    }
+
+    orig_onDoubleTap(self, _cmd, arg1);
 }
-%end
-%hook IGVideoPlayerOverlayContainerView
-- (void)_handleDoubleTapGesture:(id)arg1 {
-    CONFIRMPOSTLIKE(%orig);
+
+static void (*orig_handleDoubleTapGesture)(id, SEL, id);
+static void hooked_handleDoubleTapGesture(id self, SEL _cmd, id arg1) {
+    if ([SCIUtils getBoolPref:@"like_confirm"]) {
+        NSLog(@"[SCInsta] Confirm post like triggered");
+
+        [SCIUtils showConfirmation:^(void) {
+            orig_handleDoubleTapGesture(self, _cmd, arg1);
+        }];
+
+        return;
+    }
+
+    orig_handleDoubleTapGesture(self, _cmd, arg1);
 }
-%end
 
 // Liking reels
-%hook IGSundialViewerVideoCell
-- (void)controlsOverlayControllerDidTapLikeButton:(id)arg1 {
-    CONFIRMREELSLIKE(%orig);
+static void (*orig_videoCellControlsOverlayControllerDidTapLikeButton)(id, SEL, id);
+static void hooked_videoCellControlsOverlayControllerDidTapLikeButton(id self, SEL _cmd, id arg1) {
+    if ([SCIUtils getBoolPref:@"like_confirm_reels"]) {
+        NSLog(@"[SCInsta] Confirm reels like triggered");
+
+        [SCIUtils showConfirmation:^(void) {
+            orig_videoCellControlsOverlayControllerDidTapLikeButton(self, _cmd, arg1);
+        }];
+
+        return;
+    }
+
+    orig_videoCellControlsOverlayControllerDidTapLikeButton(self, _cmd, arg1);
 }
-- (void)controlsOverlayControllerDidLongPressLikeButton:(id)arg1 gestureRecognizer:(id)arg2 {
-    CONFIRMREELSLIKE(%orig);
+
+static void (*orig_videoCellControlsOverlayControllerDidLongPressLikeButton)(id, SEL, id, id);
+static void hooked_videoCellControlsOverlayControllerDidLongPressLikeButton(id self, SEL _cmd, id arg1, id arg2) {
+    if ([SCIUtils getBoolPref:@"like_confirm_reels"]) {
+        NSLog(@"[SCInsta] Confirm reels like triggered");
+
+        [SCIUtils showConfirmation:^(void) {
+            orig_videoCellControlsOverlayControllerDidLongPressLikeButton(self, _cmd, arg1, arg2);
+        }];
+
+        return;
+    }
+
+    orig_videoCellControlsOverlayControllerDidLongPressLikeButton(self, _cmd, arg1, arg2);
 }
-- (void)gestureController:(id)arg1 didObserveDoubleTap:(id)arg2 {
-    CONFIRMREELSLIKE(%orig);
+
+static void (*orig_videoCellGestureControllerDidObserveDoubleTap)(id, SEL, id, id);
+static void hooked_videoCellGestureControllerDidObserveDoubleTap(id self, SEL _cmd, id arg1, id arg2) {
+    if ([SCIUtils getBoolPref:@"like_confirm_reels"]) {
+        NSLog(@"[SCInsta] Confirm reels like triggered");
+
+        [SCIUtils showConfirmation:^(void) {
+            orig_videoCellGestureControllerDidObserveDoubleTap(self, _cmd, arg1, arg2);
+        }];
+
+        return;
+    }
+
+    orig_videoCellGestureControllerDidObserveDoubleTap(self, _cmd, arg1, arg2);
 }
-%end
-%hook IGSundialViewerPhotoCell
-- (void)controlsOverlayControllerDidTapLikeButton:(id)arg1 {
-    CONFIRMREELSLIKE(%orig);
+
+static void (*orig_photoCellControlsOverlayControllerDidTapLikeButton)(id, SEL, id);
+static void hooked_photoCellControlsOverlayControllerDidTapLikeButton(id self, SEL _cmd, id arg1) {
+    if ([SCIUtils getBoolPref:@"like_confirm_reels"]) {
+        NSLog(@"[SCInsta] Confirm reels like triggered");
+
+        [SCIUtils showConfirmation:^(void) {
+            orig_photoCellControlsOverlayControllerDidTapLikeButton(self, _cmd, arg1);
+        }];
+
+        return;
+    }
+
+    orig_photoCellControlsOverlayControllerDidTapLikeButton(self, _cmd, arg1);
 }
-- (void)gestureController:(id)arg1 didObserveDoubleTap:(id)arg2 {
-    CONFIRMREELSLIKE(%orig);
+
+static void (*orig_photoCellGestureControllerDidObserveDoubleTap)(id, SEL, id, id);
+static void hooked_photoCellGestureControllerDidObserveDoubleTap(id self, SEL _cmd, id arg1, id arg2) {
+    if ([SCIUtils getBoolPref:@"like_confirm_reels"]) {
+        NSLog(@"[SCInsta] Confirm reels like triggered");
+
+        [SCIUtils showConfirmation:^(void) {
+            orig_photoCellGestureControllerDidObserveDoubleTap(self, _cmd, arg1, arg2);
+        }];
+
+        return;
+    }
+
+    orig_photoCellGestureControllerDidObserveDoubleTap(self, _cmd, arg1, arg2);
 }
-%end
-%hook IGSundialViewerCarouselCell
-- (void)controlsOverlayControllerDidTapLikeButton:(id)arg1 {
-    CONFIRMREELSLIKE(%orig);
+
+static void (*orig_carouselCellControlsOverlayControllerDidTapLikeButton)(id, SEL, id);
+static void hooked_carouselCellControlsOverlayControllerDidTapLikeButton(id self, SEL _cmd, id arg1) {
+    if ([SCIUtils getBoolPref:@"like_confirm_reels"]) {
+        NSLog(@"[SCInsta] Confirm reels like triggered");
+
+        [SCIUtils showConfirmation:^(void) {
+            orig_carouselCellControlsOverlayControllerDidTapLikeButton(self, _cmd, arg1);
+        }];
+
+        return;
+    }
+
+    orig_carouselCellControlsOverlayControllerDidTapLikeButton(self, _cmd, arg1);
 }
-- (void)gestureController:(id)arg1 didObserveDoubleTap:(id)arg2 {
-    CONFIRMREELSLIKE(%orig);
+
+static void (*orig_carouselCellGestureControllerDidObserveDoubleTap)(id, SEL, id, id);
+static void hooked_carouselCellGestureControllerDidObserveDoubleTap(id self, SEL _cmd, id arg1, id arg2) {
+    if ([SCIUtils getBoolPref:@"like_confirm_reels"]) {
+        NSLog(@"[SCInsta] Confirm reels like triggered");
+
+        [SCIUtils showConfirmation:^(void) {
+            orig_carouselCellGestureControllerDidObserveDoubleTap(self, _cmd, arg1, arg2);
+        }];
+
+        return;
+    }
+
+    orig_carouselCellGestureControllerDidObserveDoubleTap(self, _cmd, arg1, arg2);
 }
-%end
 
 // Liking comments
-%hook IGCommentCellController
-- (void)commentCell:(id)arg1 didTapLikeButton:(id)arg2 {
-    CONFIRMPOSTLIKE(%orig);
+static void (*orig_commentCellDidTapLikeButton)(id, SEL, id, id);
+static void hooked_commentCellDidTapLikeButton(id self, SEL _cmd, id arg1, id arg2) {
+    if ([SCIUtils getBoolPref:@"like_confirm"]) {
+        NSLog(@"[SCInsta] Confirm post like triggered");
+
+        [SCIUtils showConfirmation:^(void) {
+            orig_commentCellDidTapLikeButton(self, _cmd, arg1, arg2);
+        }];
+
+        return;
+    }
+
+    orig_commentCellDidTapLikeButton(self, _cmd, arg1, arg2);
 }
-- (void)commentCell:(id)arg1 didTapLikedByButtonForUser:(id)arg2 {
-    CONFIRMPOSTLIKE(%orig);
+
+static void (*orig_commentCellDidTapLikedByButtonForUser)(id, SEL, id, id);
+static void hooked_commentCellDidTapLikedByButtonForUser(id self, SEL _cmd, id arg1, id arg2) {
+    if ([SCIUtils getBoolPref:@"like_confirm"]) {
+        NSLog(@"[SCInsta] Confirm post like triggered");
+
+        [SCIUtils showConfirmation:^(void) {
+            orig_commentCellDidTapLikedByButtonForUser(self, _cmd, arg1, arg2);
+        }];
+
+        return;
+    }
+
+    orig_commentCellDidTapLikedByButtonForUser(self, _cmd, arg1, arg2);
 }
-- (void)commentCellDidLongPressOnLikeButton:(id)arg1 {
-    CONFIRMPOSTLIKE(%orig);
+
+static void (*orig_commentCellDidLongPressOnLikeButton)(id, SEL, id);
+static void hooked_commentCellDidLongPressOnLikeButton(id self, SEL _cmd, id arg1) {
+    if ([SCIUtils getBoolPref:@"like_confirm"]) {
+        NSLog(@"[SCInsta] Confirm post like triggered");
+
+        [SCIUtils showConfirmation:^(void) {
+            orig_commentCellDidLongPressOnLikeButton(self, _cmd, arg1);
+        }];
+
+        return;
+    }
+
+    orig_commentCellDidLongPressOnLikeButton(self, _cmd, arg1);
 }
-- (void)commentCellDidEndLongPressOnLikeButton:(id)arg1 {
-    CONFIRMPOSTLIKE(%orig);
+
+static void (*orig_commentCellDidEndLongPressOnLikeButton)(id, SEL, id);
+static void hooked_commentCellDidEndLongPressOnLikeButton(id self, SEL _cmd, id arg1) {
+    if ([SCIUtils getBoolPref:@"like_confirm"]) {
+        NSLog(@"[SCInsta] Confirm post like triggered");
+
+        [SCIUtils showConfirmation:^(void) {
+            orig_commentCellDidEndLongPressOnLikeButton(self, _cmd, arg1);
+        }];
+
+        return;
+    }
+
+    orig_commentCellDidEndLongPressOnLikeButton(self, _cmd, arg1);
 }
-- (void)commentCellDidDoubleTap:(id)arg1 {
-    CONFIRMPOSTLIKE(%orig);
+
+static void (*orig_commentCellDidDoubleTap)(id, SEL, id);
+static void hooked_commentCellDidDoubleTap(id self, SEL _cmd, id arg1) {
+    if ([SCIUtils getBoolPref:@"like_confirm"]) {
+        NSLog(@"[SCInsta] Confirm post like triggered");
+
+        [SCIUtils showConfirmation:^(void) {
+            orig_commentCellDidDoubleTap(self, _cmd, arg1);
+        }];
+
+        return;
+    }
+
+    orig_commentCellDidDoubleTap(self, _cmd, arg1);
 }
-%end
-%hook IGFeedItemPreviewCommentCell
-- (void)_didTapLikeButton {
-    CONFIRMPOSTLIKE(%orig);
+
+static void (*orig_previewCommentCellDidTapLikeButton)(id, SEL);
+static void hooked_previewCommentCellDidTapLikeButton(id self, SEL _cmd) {
+    if ([SCIUtils getBoolPref:@"like_confirm"]) {
+        NSLog(@"[SCInsta] Confirm post like triggered");
+
+        [SCIUtils showConfirmation:^(void) {
+            orig_previewCommentCellDidTapLikeButton(self, _cmd);
+        }];
+
+        return;
+    }
+
+    orig_previewCommentCellDidTapLikeButton(self, _cmd);
 }
-%end
 
 // Liking stories
-%hook IGStoryFullscreenDefaultFooterView
-- (void)_handleLikeTapped {
-    CONFIRMPOSTLIKE(%orig);
+static void (*orig_handleLikeTapped)(id, SEL);
+static void hooked_handleLikeTapped(id self, SEL _cmd) {
+    if ([SCIUtils getBoolPref:@"like_confirm"]) {
+        NSLog(@"[SCInsta] Confirm post like triggered");
+
+        [SCIUtils showConfirmation:^(void) {
+            orig_handleLikeTapped(self, _cmd);
+        }];
+
+        return;
+    }
+
+    orig_handleLikeTapped(self, _cmd);
 }
-- (void)_likeTapped {
-    CONFIRMPOSTLIKE(%orig);
+
+static void (*orig_likeTapped)(id, SEL);
+static void hooked_likeTapped(id self, SEL _cmd) {
+    if ([SCIUtils getBoolPref:@"like_confirm"]) {
+        NSLog(@"[SCInsta] Confirm post like triggered");
+
+        [SCIUtils showConfirmation:^(void) {
+            orig_likeTapped(self, _cmd);
+        }];
+
+        return;
+    }
+
+    orig_likeTapped(self, _cmd);
 }
-- (void)inputView:(id)arg1 didTapLikeButton:(id)arg2 {
-    CONFIRMPOSTLIKE(%orig);
+
+static void (*orig_inputViewDidTapLikeButton)(id, SEL, id, id);
+static void hooked_inputViewDidTapLikeButton(id self, SEL _cmd, id arg1, id arg2) {
+    if ([SCIUtils getBoolPref:@"like_confirm"]) {
+        NSLog(@"[SCInsta] Confirm post like triggered");
+
+        [SCIUtils showConfirmation:^(void) {
+            orig_inputViewDidTapLikeButton(self, _cmd, arg1, arg2);
+        }];
+
+        return;
+    }
+
+    orig_inputViewDidTapLikeButton(self, _cmd, arg1, arg2);
 }
 
 // For some stupid reason they removed the "liketapped" methods on newer Instagram versions
 // Now we have to do a shitty workaround instead :(
 // Works 99% of the time, but sometimes clicks get through directly to the like button (somehow)
+%hook IGStoryFullscreenDefaultFooterView
 - (void)layoutSubviews {
     %orig;
 
@@ -143,8 +334,81 @@
 %end
 
 // DM like button (seems to be hidden)
-%hook IGDirectThreadViewController
-- (void)_didTapLikeButton {
-    CONFIRMPOSTLIKE(%orig);
+static void (*orig_directThreadDidTapLikeButton)(id, SEL);
+static void hooked_directThreadDidTapLikeButton(id self, SEL _cmd) {
+    if ([SCIUtils getBoolPref:@"like_confirm"]) {
+        NSLog(@"[SCInsta] Confirm post like triggered");
+
+        [SCIUtils showConfirmation:^(void) {
+            orig_directThreadDidTapLikeButton(self, _cmd);
+        }];
+
+        return;
+    }
+
+    orig_directThreadDidTapLikeButton(self, _cmd);
 }
-%end
+
+%ctor {
+    Class cls;
+
+    cls = objc_getClass("IGUFIButtonBarView");
+    if (cls) {
+        MSHookMessageEx(cls, @selector(_onLikeButtonPressed:), (IMP)hooked_onLikeButtonPressed, (IMP *)&orig_onLikeButtonPressed);
+    }
+
+    cls = objc_getClass("IGFeedPhotoView");
+    if (cls) {
+        MSHookMessageEx(cls, @selector(_onDoubleTap:), (IMP)hooked_onDoubleTap, (IMP *)&orig_onDoubleTap);
+    }
+
+    cls = objc_getClass("IGVideoPlayerOverlayContainerView");
+    if (cls) {
+        MSHookMessageEx(cls, @selector(_handleDoubleTapGesture:), (IMP)hooked_handleDoubleTapGesture, (IMP *)&orig_handleDoubleTapGesture);
+    }
+
+    cls = objc_getClass("IGSundialViewerVideoCell");
+    if (cls) {
+        MSHookMessageEx(cls, @selector(controlsOverlayControllerDidTapLikeButton:), (IMP)hooked_videoCellControlsOverlayControllerDidTapLikeButton, (IMP *)&orig_videoCellControlsOverlayControllerDidTapLikeButton);
+        MSHookMessageEx(cls, @selector(controlsOverlayControllerDidLongPressLikeButton:gestureRecognizer:), (IMP)hooked_videoCellControlsOverlayControllerDidLongPressLikeButton, (IMP *)&orig_videoCellControlsOverlayControllerDidLongPressLikeButton);
+        MSHookMessageEx(cls, @selector(gestureController:didObserveDoubleTap:), (IMP)hooked_videoCellGestureControllerDidObserveDoubleTap, (IMP *)&orig_videoCellGestureControllerDidObserveDoubleTap);
+    }
+
+    cls = objc_getClass("IGSundialViewerPhotoCell");
+    if (cls) {
+        MSHookMessageEx(cls, @selector(controlsOverlayControllerDidTapLikeButton:), (IMP)hooked_photoCellControlsOverlayControllerDidTapLikeButton, (IMP *)&orig_photoCellControlsOverlayControllerDidTapLikeButton);
+        MSHookMessageEx(cls, @selector(gestureController:didObserveDoubleTap:), (IMP)hooked_photoCellGestureControllerDidObserveDoubleTap, (IMP *)&orig_photoCellGestureControllerDidObserveDoubleTap);
+    }
+
+    cls = objc_getClass("IGSundialViewerCarouselCell");
+    if (cls) {
+        MSHookMessageEx(cls, @selector(controlsOverlayControllerDidTapLikeButton:), (IMP)hooked_carouselCellControlsOverlayControllerDidTapLikeButton, (IMP *)&orig_carouselCellControlsOverlayControllerDidTapLikeButton);
+        MSHookMessageEx(cls, @selector(gestureController:didObserveDoubleTap:), (IMP)hooked_carouselCellGestureControllerDidObserveDoubleTap, (IMP *)&orig_carouselCellGestureControllerDidObserveDoubleTap);
+    }
+
+    cls = objc_getClass("IGCommentCellController");
+    if (cls) {
+        MSHookMessageEx(cls, @selector(commentCell:didTapLikeButton:), (IMP)hooked_commentCellDidTapLikeButton, (IMP *)&orig_commentCellDidTapLikeButton);
+        MSHookMessageEx(cls, @selector(commentCell:didTapLikedByButtonForUser:), (IMP)hooked_commentCellDidTapLikedByButtonForUser, (IMP *)&orig_commentCellDidTapLikedByButtonForUser);
+        MSHookMessageEx(cls, @selector(commentCellDidLongPressOnLikeButton:), (IMP)hooked_commentCellDidLongPressOnLikeButton, (IMP *)&orig_commentCellDidLongPressOnLikeButton);
+        MSHookMessageEx(cls, @selector(commentCellDidEndLongPressOnLikeButton:), (IMP)hooked_commentCellDidEndLongPressOnLikeButton, (IMP *)&orig_commentCellDidEndLongPressOnLikeButton);
+        MSHookMessageEx(cls, @selector(commentCellDidDoubleTap:), (IMP)hooked_commentCellDidDoubleTap, (IMP *)&orig_commentCellDidDoubleTap);
+    }
+
+    cls = objc_getClass("IGFeedItemPreviewCommentCell");
+    if (cls) {
+        MSHookMessageEx(cls, @selector(_didTapLikeButton), (IMP)hooked_previewCommentCellDidTapLikeButton, (IMP *)&orig_previewCommentCellDidTapLikeButton);
+    }
+
+    cls = objc_getClass("IGStoryFullscreenDefaultFooterView");
+    if (cls) {
+        MSHookMessageEx(cls, @selector(_handleLikeTapped), (IMP)hooked_handleLikeTapped, (IMP *)&orig_handleLikeTapped);
+        MSHookMessageEx(cls, @selector(_likeTapped), (IMP)hooked_likeTapped, (IMP *)&orig_likeTapped);
+        MSHookMessageEx(cls, @selector(inputView:didTapLikeButton:), (IMP)hooked_inputViewDidTapLikeButton, (IMP *)&orig_inputViewDidTapLikeButton);
+    }
+
+    cls = objc_getClass("IGDirectThreadViewController");
+    if (cls) {
+        MSHookMessageEx(cls, @selector(_didTapLikeButton), (IMP)hooked_directThreadDidTapLikeButton, (IMP *)&orig_directThreadDidTapLikeButton);
+    }
+}

--- a/src/Features/Confirm/PostCommentConfirm.x
+++ b/src/Features/Confirm/PostCommentConfirm.x
@@ -1,13 +1,29 @@
+#import <substrate.h>
 #import "../../Utils.h"
 
-%hook IGCommentComposer.IGCommentComposerController
-- (void)onSendButtonTap {
+// NOTE: Logos' bare %orig substitution corrupts the surrounding braces when
+// used inside a nested block literal (e.g. inside a showConfirmation
+// completion handler), so this hook is implemented manually via
+// MSHookMessageEx with a captured C function pointer instead of %hook/%orig.
+
+static void (*orig_onSendButtonTap)(id, SEL);
+static void hooked_onSendButtonTap(id self, SEL _cmd) {
     if ([SCIUtils getBoolPref:@"post_comment_confirm"]) {
         NSLog(@"[SCInsta] Confirm post comment triggered");
 
-        [SCIUtils showConfirmation:^(void) { %orig; }];
-    } else {
-        return %orig;
+        [SCIUtils showConfirmation:^(void) {
+            orig_onSendButtonTap(self, _cmd);
+        }];
+
+        return;
     }
+
+    orig_onSendButtonTap(self, _cmd);
 }
-%end
+
+%ctor {
+    Class cls = objc_getClass("IGCommentComposer.IGCommentComposerController");
+    if (!cls) return;
+
+    MSHookMessageEx(cls, @selector(onSendButtonTap), (IMP)hooked_onSendButtonTap, (IMP *)&orig_onSendButtonTap);
+}

--- a/src/Features/Confirm/ShhConfirm.x
+++ b/src/Features/Confirm/ShhConfirm.x
@@ -1,33 +1,61 @@
+#import <substrate.h>
 #import "../../Utils.h"
 
-%hook IGDirectThreadViewController
-- (void)swipeableScrollManagerDidEndDraggingAboveSwipeThreshold:(id)arg1 {
+// NOTE: Logos' bare %orig substitution corrupts the surrounding braces when
+// used inside a nested block literal (e.g. inside a showConfirmation
+// completion handler), so these hooks are implemented manually via
+// MSHookMessageEx with a captured C function pointer instead of %hook/%orig.
+
+static void (*orig_swipeableScrollManagerDidEndDraggingAboveSwipeThreshold)(id, SEL, id);
+static void hooked_swipeableScrollManagerDidEndDraggingAboveSwipeThreshold(id self, SEL _cmd, id arg1) {
     if ([SCIUtils getBoolPref:@"shh_mode_confirm"]) {
         NSLog(@"[SCInsta] Confirm shh mode triggered");
 
-        [SCIUtils showConfirmation:^(void) { %orig; }];
-    } else {
-        return %orig;
+        [SCIUtils showConfirmation:^(void) {
+            orig_swipeableScrollManagerDidEndDraggingAboveSwipeThreshold(self, _cmd, arg1);
+        }];
+
+        return;
     }
+
+    orig_swipeableScrollManagerDidEndDraggingAboveSwipeThreshold(self, _cmd, arg1);
 }
 
-- (void)shhModeTransitionButtonDidTap:(id)arg1 {
+static void (*orig_shhModeTransitionButtonDidTap)(id, SEL, id);
+static void hooked_shhModeTransitionButtonDidTap(id self, SEL _cmd, id arg1) {
     if ([SCIUtils getBoolPref:@"shh_mode_confirm"]) {
         NSLog(@"[SCInsta] Confirm shh mode triggered");
 
-        [SCIUtils showConfirmation:^(void) { %orig; }];
-    } else {
-        return %orig;
+        [SCIUtils showConfirmation:^(void) {
+            orig_shhModeTransitionButtonDidTap(self, _cmd, arg1);
+        }];
+
+        return;
     }
+
+    orig_shhModeTransitionButtonDidTap(self, _cmd, arg1);
 }
 
-- (void)messageListViewControllerDidToggleShhMode:(id)arg1 {
+static void (*orig_messageListViewControllerDidToggleShhMode)(id, SEL, id);
+static void hooked_messageListViewControllerDidToggleShhMode(id self, SEL _cmd, id arg1) {
     if ([SCIUtils getBoolPref:@"shh_mode_confirm"]) {
         NSLog(@"[SCInsta] Confirm shh mode triggered");
 
-        [SCIUtils showConfirmation:^(void) { %orig; }];
-    } else {
-        return %orig;
+        [SCIUtils showConfirmation:^(void) {
+            orig_messageListViewControllerDidToggleShhMode(self, _cmd, arg1);
+        }];
+
+        return;
     }
+
+    orig_messageListViewControllerDidToggleShhMode(self, _cmd, arg1);
 }
-%end
+
+%ctor {
+    Class cls = objc_getClass("IGDirectThreadViewController");
+    if (!cls) return;
+
+    MSHookMessageEx(cls, @selector(swipeableScrollManagerDidEndDraggingAboveSwipeThreshold:), (IMP)hooked_swipeableScrollManagerDidEndDraggingAboveSwipeThreshold, (IMP *)&orig_swipeableScrollManagerDidEndDraggingAboveSwipeThreshold);
+    MSHookMessageEx(cls, @selector(shhModeTransitionButtonDidTap:), (IMP)hooked_shhModeTransitionButtonDidTap, (IMP *)&orig_shhModeTransitionButtonDidTap);
+    MSHookMessageEx(cls, @selector(messageListViewControllerDidToggleShhMode:), (IMP)hooked_messageListViewControllerDidToggleShhMode, (IMP *)&orig_messageListViewControllerDidToggleShhMode);
+}

--- a/src/Features/Confirm/StickerInteractConfirm.x
+++ b/src/Features/Confirm/StickerInteractConfirm.x
@@ -1,13 +1,29 @@
+#import <substrate.h>
 #import "../../Utils.h"
 
-%hook IGStoryViewerTapTarget
-- (void)_didTap:(id)arg1 forEvent:(id)arg2 {
+// NOTE: Logos' bare %orig substitution corrupts the surrounding braces when
+// used inside a nested block literal (e.g. inside a showConfirmation
+// completion handler), so this hook is implemented manually via
+// MSHookMessageEx with a captured C function pointer instead of %hook/%orig.
+
+static void (*orig_didTapForEvent)(id, SEL, id, id);
+static void hooked_didTapForEvent(id self, SEL _cmd, id arg1, id arg2) {
     if ([SCIUtils getBoolPref:@"sticker_interact_confirm"]) {
         NSLog(@"[SCInsta] Confirm sticker interact triggered");
 
-        [SCIUtils showConfirmation:^(void) { %orig; }];
-    } else {
-        return %orig;
+        [SCIUtils showConfirmation:^(void) {
+            orig_didTapForEvent(self, _cmd, arg1, arg2);
+        }];
+
+        return;
     }
+
+    orig_didTapForEvent(self, _cmd, arg1, arg2);
 }
-%end
+
+%ctor {
+    Class cls = objc_getClass("IGStoryViewerTapTarget");
+    if (!cls) return;
+
+    MSHookMessageEx(cls, @selector(_didTap:forEvent:), (IMP)hooked_didTapForEvent, (IMP *)&orig_didTapForEvent);
+}

--- a/src/Features/Feed/HideFeedItems.xm
+++ b/src/Features/Feed/HideFeedItems.xm
@@ -116,7 +116,8 @@ static NSArray *removeItemsInList(NSArray *list, BOOL isFeed) {
 // Suggested posts/reels
 %hook IGMainFeedListAdapterDataSource
 - (NSArray *)objectsForListAdapter:(id)arg1 {
-    NSArray *filteredObjs = removeItemsInList(%orig, YES);
+    NSArray *origObjs = %orig(arg1);
+    NSArray *filteredObjs = removeItemsInList(origObjs, YES);
 
     // Remove loading spinner at end of feed (if 5 or less items in feed)
     NSUInteger arrayLength = [filteredObjs count];
@@ -134,7 +135,8 @@ static NSArray *removeItemsInList(NSArray *list, BOOL isFeed) {
 %end
 %hook IGSundialFeedDataSource
 - (NSArray *)objectsForListAdapter:(id)arg1 {
-    NSArray *filteredList = removeItemsInList(%orig, NO);
+    NSArray *origObjs = %orig(arg1);
+    NSArray *filteredList = removeItemsInList(origObjs, NO);
 
     if ([SCIUtils getBoolPref:@"prevent_doom_scrolling"]) {
         double reelCount = [SCIUtils getDoublePref:@"doom_scrolling_reel_count"];
@@ -147,7 +149,8 @@ static NSArray *removeItemsInList(NSArray *list, BOOL isFeed) {
 %hook IGContextualFeedViewController
 - (NSArray *)objectsForListAdapter:(id)arg1 {
     if ([SCIUtils getBoolPref:@"hide_ads"]) {
-        return removeItemsInList(%orig, NO);
+        NSArray *origObjs = %orig(arg1);
+        return removeItemsInList(origObjs, NO);
     }
 
     return %orig;
@@ -156,7 +159,8 @@ static NSArray *removeItemsInList(NSArray *list, BOOL isFeed) {
 %hook IGVideoFeedViewController
 - (NSArray *)objectsForListAdapter:(id)arg1 {
     if ([SCIUtils getBoolPref:@"hide_ads"]) {
-        return removeItemsInList(%orig, NO);
+        NSArray *origObjs = %orig(arg1);
+        return removeItemsInList(origObjs, NO);
     }
 
     return %orig;
@@ -165,7 +169,8 @@ static NSArray *removeItemsInList(NSArray *list, BOOL isFeed) {
 %hook IGChainingFeedViewController
 - (NSArray *)objectsForListAdapter:(id)arg1 {
     if ([SCIUtils getBoolPref:@"hide_ads"]) {
-        return removeItemsInList(%orig, NO);
+        NSArray *origObjs = %orig(arg1);
+        return removeItemsInList(origObjs, NO);
     }
 
     return %orig;
@@ -260,7 +265,8 @@ static NSArray *removeItemsInList(NSArray *list, BOOL isFeed) {
 %hook IGExploreListKitDataSource
 - (NSArray *)objectsForListAdapter:(id)arg1 {
     if ([SCIUtils getBoolPref:@"hide_ads"]) {
-        return removeItemsInList(%orig, NO);
+        NSArray *origObjs = %orig(arg1);
+        return removeItemsInList(origObjs, NO);
     }
 
     return %orig;
@@ -270,7 +276,8 @@ static NSArray *removeItemsInList(NSArray *list, BOOL isFeed) {
 %hook _TtC28IGExploreViewControllerSwift26IGExploreListKitDataSource
 - (NSArray *)objectsForListAdapter:(id)arg1 {
     if ([SCIUtils getBoolPref:@"hide_ads"]) {
-        return removeItemsInList(%orig, NO);
+        NSArray *origObjs = %orig(arg1);
+        return removeItemsInList(origObjs, NO);
     }
 
     return %orig;

--- a/src/Features/General/NoSuggestedChats.x
+++ b/src/Features/General/NoSuggestedChats.x
@@ -4,7 +4,8 @@
 // Channels dms tab (header)
 %hook IGDirectInboxHeaderSectionController
 - (id)viewModel {
-    if ([[%orig title] isEqualToString:@"Suggested"]) {
+    id origViewModel = %orig;
+    if ([[origViewModel title] isEqualToString:@"Suggested"]) {
 
         if ([SCIUtils getBoolPref:@"no_suggested_chats"]) {
             NSLog(@"[SCInsta] Hiding suggested chats (header: channels tab)");
@@ -14,6 +15,6 @@
 
     }
 
-    return %orig;
+    return origViewModel;
 }
 %end

--- a/src/Features/Reels/ReelsPlayback.xm
+++ b/src/Features/Reels/ReelsPlayback.xm
@@ -1,4 +1,42 @@
+#import <substrate.h>
 #import "../../Utils.h"
+
+// NOTE: Logos' bare %orig substitution corrupts the surrounding braces when
+// used inside a nested block literal (e.g. inside a showConfirmation
+// completion handler), so the reel-refresh confirmation hook below is
+// implemented manually via MSHookMessageEx with a captured C function
+// pointer instead of %hook/%orig.
+static void (*orig_refreshReelsWithParamsForNetworkRequest)(id, SEL, NSInteger, BOOL);
+static void hooked_refreshReelsWithParamsForNetworkRequest(id self, SEL _cmd, NSInteger arg1, BOOL arg2) {
+    if ([SCIUtils getBoolPref:@"prevent_doom_scrolling"]) {
+        IGRefreshControl *_refreshControl = MSHookIvar<IGRefreshControl *>(self, "_refreshControl");
+        [self refreshControlDidEndFinishLoadingAnimation:_refreshControl];
+
+        return;
+    }
+
+    if ([SCIUtils getBoolPref:@"refresh_reel_confirm"]) {
+        NSLog(@"[SCInsta] Reel refresh triggered");
+
+        [SCIUtils showConfirmation:^(void) {
+            orig_refreshReelsWithParamsForNetworkRequest(self, _cmd, arg1, arg2);
+        }
+                     cancelHandler:^(void) {
+                         IGRefreshControl *_refreshControl = MSHookIvar<IGRefreshControl *>(self, "_refreshControl");
+                         [self refreshControlDidEndFinishLoadingAnimation:_refreshControl];
+                     }
+                             title:@"Refresh Reels"];
+    } else {
+        orig_refreshReelsWithParamsForNetworkRequest(self, _cmd, arg1, arg2);
+    }
+}
+
+%ctor {
+    Class cls = objc_getClass("IGSundialFeedViewController");
+    if (!cls) return;
+
+    MSHookMessageEx(cls, @selector(_refreshReelsWithParamsForNetworkRequest:userDidPullToRefresh:), (IMP)hooked_refreshReelsWithParamsForNetworkRequest, (IMP *)&orig_refreshReelsWithParamsForNetworkRequest);
+}
 
 %hook IGSundialPlaybackControlsTestConfiguration
 - (id)initWithLauncherSet:(id)set
@@ -25,30 +63,6 @@
     }
 
     return %orig(set, userTapPauseEnabled, controls, previewThumbEnabled, userMinSec, seekSec, tapSec, userDuration, userShortScrubberEnabled);
-}
-%end
-
-%hook IGSundialFeedViewController
-- (void)_refreshReelsWithParamsForNetworkRequest:(NSInteger)arg1 userDidPullToRefresh:(BOOL)arg2 {
-    if ([SCIUtils getBoolPref:@"prevent_doom_scrolling"]) {
-        IGRefreshControl *_refreshControl = MSHookIvar<IGRefreshControl *>(self, "_refreshControl");
-        [self refreshControlDidEndFinishLoadingAnimation:_refreshControl];
-
-        return;
-    }
-
-    if ([SCIUtils getBoolPref:@"refresh_reel_confirm"]) {
-        NSLog(@"[SCInsta] Reel refresh triggered");
-        
-        [SCIUtils showConfirmation:^(void) { %orig(arg1, arg2); }
-                     cancelHandler:^(void) {
-                         IGRefreshControl *_refreshControl = MSHookIvar<IGRefreshControl *>(self, "_refreshControl");
-                         [self refreshControlDidEndFinishLoadingAnimation:_refreshControl];
-                     }
-                             title:@"Refresh Reels"];
-    } else {
-        return %orig(arg1, arg2);
-    }
 }
 %end
 

--- a/src/Features/StoriesAndMessages/DisableInstantsCreation.x
+++ b/src/Features/StoriesAndMessages/DisableInstantsCreation.x
@@ -1,32 +1,54 @@
 #import "../../Utils.h"
 
-#define QUICKSNAPENABLED(orig) return [SCIUtils getBoolPref:@"disable_instants_creation"] ? false : orig;
-
 // Demangled name: IGQuickSnapExperimentation.IGQuickSnapExperimentationHelper
 %hook _TtC26IGQuickSnapExperimentation32IGQuickSnapExperimentationHelper
 + (_Bool)isQuicksnapEnabled:(id)enabled {
-    QUICKSNAPENABLED(%orig);
+    if ([SCIUtils getBoolPref:@"disable_instants_creation"]) {
+        return false;
+    }
+    return %orig(enabled);
 }
 + (_Bool)isQuicksnapEnabledInFeed:(id)feed {
-    QUICKSNAPENABLED(%orig);
+    if ([SCIUtils getBoolPref:@"disable_instants_creation"]) {
+        return false;
+    }
+    return %orig(feed);
 }
 + (_Bool)isQuicksnapEnabledInInbox:(id)inbox {
-    QUICKSNAPENABLED(%orig);
+    if ([SCIUtils getBoolPref:@"disable_instants_creation"]) {
+        return false;
+    }
+    return %orig(inbox);
 }
 + (_Bool)isQuicksnapEnabledInStories:(id)stories {
-    QUICKSNAPENABLED(%orig);
+    if ([SCIUtils getBoolPref:@"disable_instants_creation"]) {
+        return false;
+    }
+    return %orig(stories);
 }
 + (_Bool)isQuicksnapEnabledInNotesTray:(id)tray {
-    QUICKSNAPENABLED(%orig);
+    if ([SCIUtils getBoolPref:@"disable_instants_creation"]) {
+        return false;
+    }
+    return %orig(tray);
 }
 + (_Bool)isQuicksnapEnabledInNotesTrayWithPeek:(id)peek {
-    QUICKSNAPENABLED(%orig);
+    if ([SCIUtils getBoolPref:@"disable_instants_creation"]) {
+        return false;
+    }
+    return %orig(peek);
 }
 + (_Bool)isQuicksnapEnabledInNotesTrayWithPog:(id)pog {
-    QUICKSNAPENABLED(%orig);
+    if ([SCIUtils getBoolPref:@"disable_instants_creation"]) {
+        return false;
+    }
+    return %orig(pog);
 }
 + (_Bool)isQuicksnapNotesTrayEmptyPogEnabled:(id)enabled {
-    QUICKSNAPENABLED(%orig);
+    if ([SCIUtils getBoolPref:@"disable_instants_creation"]) {
+        return false;
+    }
+    return %orig(enabled);
 }
 // + (_Bool)isStoriesSpringEnabled:(id)enabled {
 //     return true;

--- a/src/Tweak.x
+++ b/src/Tweak.x
@@ -5,13 +5,6 @@
 
 ///////////////////////////////////////////////////////////
 
-// Screenshot handlers
-
-#define VOID_HANDLESCREENSHOT(orig) [SCIUtils getBoolPref:@"remove_screenshot_alert"] ? nil : orig;
-#define NONVOID_HANDLESCREENSHOT(orig) return VOID_HANDLESCREENSHOT(orig)
-
-///////////////////////////////////////////////////////////
-
 // * Tweak version *
 NSString *SCIVersionString = @"v1.1.1";
 
@@ -95,19 +88,24 @@ BOOL dmVisualMsgsViewedButtonEnabled = false;
 
 %hook IGDSLauncherConfig
 - (_Bool)isLiquidGlassInAppNotificationEnabled {
-    return [SCIUtils liquidGlassEnabledBool:%orig];
+    _Bool origEnabled = %orig;
+    return [SCIUtils liquidGlassEnabledBool:origEnabled];
 }
 - (_Bool)isLiquidGlassContextMenuEnabled{
-    return [SCIUtils liquidGlassEnabledBool:%orig];
+    _Bool origEnabled = %orig;
+    return [SCIUtils liquidGlassEnabledBool:origEnabled];
 }
 - (_Bool)isLiquidGlassToastEnabled {
-    return [SCIUtils liquidGlassEnabledBool:%orig];
+    _Bool origEnabled = %orig;
+    return [SCIUtils liquidGlassEnabledBool:origEnabled];
 }
 - (_Bool)isLiquidGlassToastPeekEnabled {
-    return [SCIUtils liquidGlassEnabledBool:%orig];
+    _Bool origEnabled = %orig;
+    return [SCIUtils liquidGlassEnabledBool:origEnabled];
 }
 - (_Bool)isLiquidGlassAlertDialogEnabled {
-    return [SCIUtils liquidGlassEnabledBool:%orig];
+    _Bool origEnabled = %orig;
+    return [SCIUtils liquidGlassEnabledBool:origEnabled];
 }
 %end
 
@@ -132,20 +130,39 @@ shouldPersistLastBugReportId:(id)arg6
 
 // Disable anti-screenshot feature on visual messages
 %hook IGStoryViewerContainerView
-- (void)setShouldBlockScreenshot:(BOOL)arg1 viewModel:(id)arg2 { VOID_HANDLESCREENSHOT(%orig); }
+- (void)setShouldBlockScreenshot:(BOOL)arg1 viewModel:(id)arg2 {
+    if (![SCIUtils getBoolPref:@"remove_screenshot_alert"]) {
+        %orig(arg1, arg2);
+    }
+}
 %end
 
 // Disable screenshot logging/detection
 %hook IGDirectVisualMessageViewerSession
-- (id)visualMessageViewerController:(id)arg1 didDetectScreenshotForVisualMessage:(id)arg2 atIndex:(NSInteger)arg3 { NONVOID_HANDLESCREENSHOT(%orig); }
+- (id)visualMessageViewerController:(id)arg1 didDetectScreenshotForVisualMessage:(id)arg2 atIndex:(NSInteger)arg3 {
+    if ([SCIUtils getBoolPref:@"remove_screenshot_alert"]) {
+        return nil;
+    }
+    return %orig(arg1, arg2, arg3);
+}
 %end
 
 %hook IGDirectVisualMessageReplayService
-- (id)visualMessageViewerController:(id)arg1 didDetectScreenshotForVisualMessage:(id)arg2 atIndex:(NSInteger)arg3 { NONVOID_HANDLESCREENSHOT(%orig); }
+- (id)visualMessageViewerController:(id)arg1 didDetectScreenshotForVisualMessage:(id)arg2 atIndex:(NSInteger)arg3 {
+    if ([SCIUtils getBoolPref:@"remove_screenshot_alert"]) {
+        return nil;
+    }
+    return %orig(arg1, arg2, arg3);
+}
 %end
 
 %hook IGDirectVisualMessageReportService
-- (id)visualMessageViewerController:(id)arg1 didDetectScreenshotForVisualMessage:(id)arg2 atIndex:(NSInteger)arg3 { NONVOID_HANDLESCREENSHOT(%orig); }
+- (id)visualMessageViewerController:(id)arg1 didDetectScreenshotForVisualMessage:(id)arg2 atIndex:(NSInteger)arg3 {
+    if ([SCIUtils getBoolPref:@"remove_screenshot_alert"]) {
+        return nil;
+    }
+    return %orig(arg1, arg2, arg3);
+}
 %end
 
 %hook IGDirectVisualMessageScreenshotSafetyLogger
@@ -160,32 +177,77 @@ shouldPersistLastBugReportId:(id)arg6
 %end
 
 %hook IGScreenshotObserver
-- (id)initForController:(id)arg1 { NONVOID_HANDLESCREENSHOT(%orig); }
+- (id)initForController:(id)arg1 {
+    if ([SCIUtils getBoolPref:@"remove_screenshot_alert"]) {
+        return nil;
+    }
+    return %orig(arg1);
+}
 %end
 
 %hook IGScreenshotObserverDelegate
-- (void)screenshotObserverDidSeeScreenshotTaken:(id)arg1 { VOID_HANDLESCREENSHOT(%orig); }
-- (void)screenshotObserverDidSeeActiveScreenCapture:(id)arg1 event:(NSInteger)arg2 { VOID_HANDLESCREENSHOT(%orig); }
+- (void)screenshotObserverDidSeeScreenshotTaken:(id)arg1 {
+    if (![SCIUtils getBoolPref:@"remove_screenshot_alert"]) {
+        %orig(arg1);
+    }
+}
+- (void)screenshotObserverDidSeeActiveScreenCapture:(id)arg1 event:(NSInteger)arg2 {
+    if (![SCIUtils getBoolPref:@"remove_screenshot_alert"]) {
+        %orig(arg1, arg2);
+    }
+}
 %end
 
 %hook IGDirectMediaViewerViewController
-- (void)screenshotObserverDidSeeScreenshotTaken:(id)arg1 { VOID_HANDLESCREENSHOT(%orig); }
-- (void)screenshotObserverDidSeeActiveScreenCapture:(id)arg1 event:(NSInteger)arg2 { VOID_HANDLESCREENSHOT(%orig); }
+- (void)screenshotObserverDidSeeScreenshotTaken:(id)arg1 {
+    if (![SCIUtils getBoolPref:@"remove_screenshot_alert"]) {
+        %orig(arg1);
+    }
+}
+- (void)screenshotObserverDidSeeActiveScreenCapture:(id)arg1 event:(NSInteger)arg2 {
+    if (![SCIUtils getBoolPref:@"remove_screenshot_alert"]) {
+        %orig(arg1, arg2);
+    }
+}
 %end
 
 %hook IGStoryViewerViewController
-- (void)screenshotObserverDidSeeScreenshotTaken:(id)arg1 { VOID_HANDLESCREENSHOT(%orig); }
-- (void)screenshotObserverDidSeeActiveScreenCapture:(id)arg1 event:(NSInteger)arg2 { VOID_HANDLESCREENSHOT(%orig); }
+- (void)screenshotObserverDidSeeScreenshotTaken:(id)arg1 {
+    if (![SCIUtils getBoolPref:@"remove_screenshot_alert"]) {
+        %orig(arg1);
+    }
+}
+- (void)screenshotObserverDidSeeActiveScreenCapture:(id)arg1 event:(NSInteger)arg2 {
+    if (![SCIUtils getBoolPref:@"remove_screenshot_alert"]) {
+        %orig(arg1, arg2);
+    }
+}
 %end
 
 %hook IGSundialFeedViewController
-- (void)screenshotObserverDidSeeScreenshotTaken:(id)arg1 { VOID_HANDLESCREENSHOT(%orig); }
-- (void)screenshotObserverDidSeeActiveScreenCapture:(id)arg1 event:(NSInteger)arg2 { VOID_HANDLESCREENSHOT(%orig); }
+- (void)screenshotObserverDidSeeScreenshotTaken:(id)arg1 {
+    if (![SCIUtils getBoolPref:@"remove_screenshot_alert"]) {
+        %orig(arg1);
+    }
+}
+- (void)screenshotObserverDidSeeActiveScreenCapture:(id)arg1 event:(NSInteger)arg2 {
+    if (![SCIUtils getBoolPref:@"remove_screenshot_alert"]) {
+        %orig(arg1, arg2);
+    }
+}
 %end
 
 %hook IGDirectVisualMessageViewerController
-- (void)screenshotObserverDidSeeScreenshotTaken:(id)arg1 { VOID_HANDLESCREENSHOT(%orig); }
-- (void)screenshotObserverDidSeeActiveScreenCapture:(id)arg1 event:(NSInteger)arg2 { VOID_HANDLESCREENSHOT(%orig); }
+- (void)screenshotObserverDidSeeScreenshotTaken:(id)arg1 {
+    if (![SCIUtils getBoolPref:@"remove_screenshot_alert"]) {
+        %orig(arg1);
+    }
+}
+- (void)screenshotObserverDidSeeActiveScreenCapture:(id)arg1 event:(NSInteger)arg2 {
+    if (![SCIUtils getBoolPref:@"remove_screenshot_alert"]) {
+        %orig(arg1, arg2);
+    }
+}
 %end
 
 /////////////////////////////////////////////////////////////////////////////
@@ -593,29 +655,42 @@ shouldPersistLastBugReportId:(id)arg6
 
 // Confirm buttons
 
-%hook IGFeedItemUFICell
-- (void)UFIButtonBarDidTapOnLike:(id)arg1 {
+// NOTE: Logos' bare %orig substitution corrupts the surrounding braces when
+// used inside a nested block literal (e.g. inside a showConfirmation
+// completion handler). The two hooks below that defer to a confirmation
+// dialog are implemented manually via MSHookMessageEx with a captured C
+// function pointer instead of %hook/%orig.
+static void (*orig_UFIButtonBarDidTapOnLike)(id, SEL, id);
+static void hooked_UFIButtonBarDidTapOnLike(id self, SEL _cmd, id arg1) {
     if ([SCIUtils getBoolPref:@"like_confirm"]) {
         NSLog(@"[SCInsta] Confirm post like triggered");
 
-        [SCIUtils showConfirmation:^(void) { %orig; }];
+        [SCIUtils showConfirmation:^(void) {
+            orig_UFIButtonBarDidTapOnLike(self, _cmd, arg1);
+        }];
+
+        return;
     }
-    else {
-        return %orig;
-    }  
+
+    orig_UFIButtonBarDidTapOnLike(self, _cmd, arg1);
 }
 
-- (void)UFIButtonBarDidTapOnRepost:(id)arg1 {
+static void (*orig_UFIButtonBarDidTapOnRepost)(id, SEL, id);
+static void hooked_UFIButtonBarDidTapOnRepost(id self, SEL _cmd, id arg1) {
     if ([SCIUtils getBoolPref:@"repost_confirm"]) {
         NSLog(@"[SCInsta] Confirm repost triggered");
 
-        [SCIUtils showConfirmation:^(void) { %orig; }];
+        [SCIUtils showConfirmation:^(void) {
+            orig_UFIButtonBarDidTapOnRepost(self, _cmd, arg1);
+        }];
+
+        return;
     }
-    else {
-        return %orig;
-    }
+
+    orig_UFIButtonBarDidTapOnRepost(self, _cmd, arg1);
 }
 
+%hook IGFeedItemUFICell
 - (void)UFIButtonBarDidLongPressOnRepost:(id)arg1 {
     if ([SCIUtils getBoolPref:@"repost_confirm"]) {
         NSLog(@"[SCInsta] Confirm repost triggered (long press ignored)");
@@ -634,32 +709,40 @@ shouldPersistLastBugReportId:(id)arg6
 }
 %end
 
-%hook IGSundialViewerVerticalUFI
-- (void)_didTapLikeButton:(id)arg1 {
+static void (*orig_verticalUFIDidTapLikeButton)(id, SEL, id);
+static void hooked_verticalUFIDidTapLikeButton(id self, SEL _cmd, id arg1) {
     if ([SCIUtils getBoolPref:@"like_confirm_reels"]) {
         NSLog(@"[SCInsta] Confirm reels like triggered");
 
-        [SCIUtils showConfirmation:^(void) { %orig; }];
+        [SCIUtils showConfirmation:^(void) {
+            orig_verticalUFIDidTapLikeButton(self, _cmd, arg1);
+        }];
+
+        return;
     }
-    else {
-        return %orig;
-    }
+
+    orig_verticalUFIDidTapLikeButton(self, _cmd, arg1);
 }
 
-- (void)_didLongPressLikeButton:(id)arg1 {
-    if ([SCIUtils getBoolPref:@"like_confirm_reels"]) {
-        NSLog(@"[SCInsta] Confirm repost triggered (long press ignored)");
-    }
-    else {
-        return %orig;
-    }
-}
-
-- (void)_didTapRepostButton:(id)arg1 {
+static void (*orig_verticalUFIDidTapRepostButton)(id, SEL, id);
+static void hooked_verticalUFIDidTapRepostButton(id self, SEL _cmd, id arg1) {
     if ([SCIUtils getBoolPref:@"repost_confirm"]) {
         NSLog(@"[SCInsta] Confirm repost triggered");
 
-        [SCIUtils showConfirmation:^(void) { %orig; }];
+        [SCIUtils showConfirmation:^(void) {
+            orig_verticalUFIDidTapRepostButton(self, _cmd, arg1);
+        }];
+
+        return;
+    }
+
+    orig_verticalUFIDidTapRepostButton(self, _cmd, arg1);
+}
+
+%hook IGSundialViewerVerticalUFI
+- (void)_didLongPressLikeButton:(id)arg1 {
+    if ([SCIUtils getBoolPref:@"like_confirm_reels"]) {
+        NSLog(@"[SCInsta] Confirm repost triggered (long press ignored)");
     }
     else {
         return %orig;
@@ -675,6 +758,22 @@ shouldPersistLastBugReportId:(id)arg6
     }
 }
 %end
+
+%ctor {
+    Class cls;
+
+    cls = objc_getClass("IGFeedItemUFICell");
+    if (cls) {
+        MSHookMessageEx(cls, @selector(UFIButtonBarDidTapOnLike:), (IMP)hooked_UFIButtonBarDidTapOnLike, (IMP *)&orig_UFIButtonBarDidTapOnLike);
+        MSHookMessageEx(cls, @selector(UFIButtonBarDidTapOnRepost:), (IMP)hooked_UFIButtonBarDidTapOnRepost, (IMP *)&orig_UFIButtonBarDidTapOnRepost);
+    }
+
+    cls = objc_getClass("IGSundialViewerVerticalUFI");
+    if (cls) {
+        MSHookMessageEx(cls, @selector(_didTapLikeButton:), (IMP)hooked_verticalUFIDidTapLikeButton, (IMP *)&orig_verticalUFIDidTapLikeButton);
+        MSHookMessageEx(cls, @selector(_didTapRepostButton:), (IMP)hooked_verticalUFIDidTapRepostButton, (IMP *)&orig_verticalUFIDidTapRepostButton);
+    }
+}
 
 /////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Previously, many files caused the error “Invalid argument structure in %orig” during compilation. This commit fixes that issue and other issues related to %orig syntax.

The GitHub action "Build and package SCInsta" now works perfectly. The app and tweaks also work perfectly. Sorry for the long commit—it's the only way I've found to fix this problem.