### PR TITLE
Fix: Resolve %orig argument structure error in ReelsPlayback.xm

### DIFF
--- a/src/Features/Reels/ReelsPlayback.xm
+++ b/src/Features/Reels/ReelsPlayback.xm
@@ -40,7 +40,11 @@
     if ([SCIUtils getBoolPref:@"refresh_reel_confirm"]) {
         NSLog(@"[SCInsta] Reel refresh triggered");
         
-        [SCIUtils showConfirmation:^(void) { %orig(arg1, arg2); }
+        // Capture the original arguments for use in the block
+        NSInteger refreshArg = arg1;
+        BOOL pullToRefreshArg = arg2;
+        
+        [SCIUtils showConfirmation:^(void) { %orig(refreshArg, pullToRefreshArg); }
                      cancelHandler:^(void) {
                          IGRefreshControl *_refreshControl = MSHookIvar<IGRefreshControl *>(self, "_refreshControl");
                          [self refreshControlDidEndFinishLoadingAnimation:_refreshControl];


### PR DESCRIPTION
- Capture method arguments (arg1, arg2) into local variables before passing them to the confirmation block
- This provides clear context for the Logos preprocessor to resolve the %orig call
- Fixes "Invalid argument structure in %orig" error on line 43