### PR TITLE
 fix(ci): pin Logos to a known-good commit to unbreak both build workflows

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -49,6 +49,20 @@ jobs:
                 ref: master
                 path: ${{ github.workspace }}/theos
                 submodules: recursive
+
+            # theos/logos master (777925d, theos/logos#114) rewrote %orig handling: it now
+            # replaces everything from %orig to end-of-line and re-appends only ";", so any
+            # %orig that is not alone on its line -- VOID_HANDLESCREENSHOT(%orig),
+            # [SCIUtils liquidGlassEnabledBool:%orig], removeItemsInList(%orig, YES) -- loses
+            # its closing bracket and the generated code no longer compiles. a623700 is the
+            # commit directly before that change; drop this step once #114 is fixed upstream.
+            - name: Pin Logos to known-good version
+              run: |
+                cd "$THEOS/vendor/logos"
+                git fetch --depth=1 origin a62370066a97e36d59b200a9fa10c5091f5e8972
+                git checkout a62370066a97e36d59b200a9fa10c5091f5e8972
+              env:
+                THEOS: ${{ github.workspace }}/theos
         
             - name: SDK Caching
               id: SDK

--- a/.github/workflows/buildtweak.yml
+++ b/.github/workflows/buildtweak.yml
@@ -37,6 +37,20 @@ jobs:
                 ref: master
                 path: ${{ github.workspace }}/theos
                 submodules: recursive
+
+            # theos/logos master (777925d, theos/logos#114) rewrote %orig handling: it now
+            # replaces everything from %orig to end-of-line and re-appends only ";", so any
+            # %orig that is not alone on its line -- VOID_HANDLESCREENSHOT(%orig),
+            # [SCIUtils liquidGlassEnabledBool:%orig], removeItemsInList(%orig, YES) -- loses
+            # its closing bracket and the generated code no longer compiles. a623700 is the
+            # commit directly before that change; drop this step once #114 is fixed upstream.
+            - name: Pin Logos to known-good version
+              run: |
+                cd "$THEOS/vendor/logos"
+                git fetch --depth=1 origin a62370066a97e36d59b200a9fa10c5091f5e8972
+                git checkout a62370066a97e36d59b200a9fa10c5091f5e8972
+              env:
+                THEOS: ${{ github.workspace }}/theos
         
             - name: SDK Caching
               id: SDK


### PR DESCRIPTION
Closes #292

## Problem

Both build workflows currently fail during Logos preprocessing:

```
src/Features/Reels/ReelsPlayback.xm:43: error: Invalid argument structure in %orig
make[3]: *** [.../ReelsPlayback.xm.mm] Error 255
```

This affects anyone forking the repo and running the workflows — nothing in SCInsta changed.

## Cause

`buildapp.yml` and `buildtweak.yml` check out `theos/theos` with `ref: master` and
`submodules: recursive`, so they always pull the newest Logos. On 2026-06-29,
[theos/logos#114](https://github.com/theos/logos/pull/114) ("Support multi-line block
arguments in `%orig` calls", commit `777925d`) rewrote the `%orig` handler: it now replaces
everything from `%orig` to the end of the line and re-appends only `;`.

Every `%orig` that is **not alone on its line** therefore loses the rest of its line,
including closing brackets:

| Source | After preprocessing |
|---|---|
| `VOID_HANDLESCREENSHOT(%orig);` | `VOID_HANDLESCREENSHOT(...;` |
| `return [SCIUtils liquidGlassEnabledBool:%orig];` | `return [SCIUtils liquidGlassEnabledBool:...;` |
| `[SCIUtils showConfirmation:^(void) { %orig; }];` | `[SCIUtils showConfirmation:^(void) { ...;` |

Hence the `expected ']'` and `unterminated function-like macro invocation` errors further
down the build. SCInsta uses this idiom in ~232 places; the code is correct and unchanged.

## Fix

A `Pin Logos to known-good version` step in both workflows, right after `Setup Theos`:

```yaml
- name: Pin Logos to known-good version
  run: |
    cd "$THEOS/vendor/logos"
    git fetch --depth=1 origin a62370066a97e36d59b200a9fa10c5091f5e8972
    git checkout a62370066a97e36d59b200a9fa10c5091f5e8972
  env:
    THEOS: ${{ github.workspace }}/theos
```

`a623700` is the **direct parent** of `777925d`, so only the regression is excluded and every
other upstream Logos fix is retained. Only the two workflow files change — no source edits.

## Verification

`logos.pl` was run over all 37 sources under `src/`, and the generated output checked for
balanced `()`, `{}` and `[]` (comments and string/char literals stripped first):

| Logos commit | files checked | broken |
|---|---|---|
| `777925d` (current master) | 37 | **14** |
| `a623700` (pinned) | 37 | **0** |

Run A reproduced the reported `ReelsPlayback.xm:43` error exactly; the other 13 files produced
unbalanced output, worst being `src/Tweak.x` (`()+15 {}+19 []+9`).

The pin step itself was validated against a shallow clone of the public remote — the same
state `actions/checkout` with `submodules: recursive` leaves behind — confirming that
`git fetch --depth=1 origin <sha>` resolves a specific commit on `theos/logos`.

## Notes

- The pin should be removed once the regression is fixed upstream. It is **not yet reported**
  on `theos/logos`, so an upstream issue is still worth filing.
- Related but non-overlapping: #255 / #277 pin GitHub *Actions* to commit SHAs. Those do not
  cover the Theos/Logos submodule, which is what breaks here. #277 edits the `uses:` line of
  the same `Setup Theos` step, so the two touch adjacent lines but different content.